### PR TITLE
Added force_schema_check to fleetcommander configuration

### DIFF
--- a/plugin/etc/ipa/fleetcommander.conf
+++ b/plugin/etc/ipa/fleetcommander.conf
@@ -4,4 +4,5 @@
 
 [global]
 interactive = False
+force_schema_check = True
 


### PR DESCRIPTION
Added forced schema updating to avoid errors connecting to IPA server when cache has not been updated after plugin installation.