### PR TITLE
Fix profile renaming

### DIFF
--- a/plugin/ipaserver/plugins/deskprofile.py
+++ b/plugin/ipaserver/plugins/deskprofile.py
@@ -141,8 +141,7 @@ class deskprofile(LDAPObject):
         'cn', 'description',
     ]
     uuid_attribute = 'ipauniqueid'
-    rdn_is_primary_key = True
-
+    allow_rename = True
     managed_permissions = {
         'System: Read FleetCommander Desktop Profile': {
             'ipapermbindruletype': 'all',
@@ -263,7 +262,7 @@ class deskprofilerule(LDAPObject):
         'seealso',
     ]
     uuid_attribute = 'ipauniqueid'
-    rdn_is_primary_key = True
+    allow_rename = True
     attribute_members = {
         'memberuser': ['user', 'group'],
         'memberhost': ['host', 'hostgroup'],


### PR DESCRIPTION
FreeIPA renaming operations were reworked in
https://github.com/freeipa/freeipa/pull/617

The rdn_is_primary_key attribute was replaced with
new allow_rename one.

Fixes: https://github.com/abbra/freeipa-desktop-profile/issues/11